### PR TITLE
Moving metadata into YAML

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,17 +1,17 @@
 ---
 layout: workshop      # DON'T CHANGE THIS.
 root: .               # DON'T CHANGE THIS EITHER.  (THANK YOU.)
-carpentry: "FIXME"    # Instructor Training
-venue: "FIXME"        # Online via Zoom
-language: "FIXME"     # EN
-humandate: "FIXME"    # August 16-17, 2017
-humantime: "FIXME"    # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
-startdate: FIXME      # 2017-08-16
-enddate: FIXME        # 2017-08-16
-instructor: ["FIXME"] # Greg Wilson and Kari Jordan
-helper: ["FIXME"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
-contact: ["maneesha@carpentries.org"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
-collaborative_notes:             # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document
+carpentry: "swc"
+venue: "Online via Zoom"
+language: "en"
+humandate: "August 16-17, 2017"
+humantime: "9:00 am - 4:30 pm"
+startdate: 2017-08-16
+enddate: 2017-08-16
+instructor: ["Kari Jordan", "Greg Wilson"]
+helper: []
+contact: ["maneesha@carpentries.org"]
+collaborative_notes:
 ---
 
 <!-- See instructions in the comments below for how to edit specific sections of this workshop template. -->


### PR DESCRIPTION
Everything between `---` and `---` at the top of the page is name:value pairs, and the `#` symbol marks a comment. Putting all the new content after the `#` on each line made it invisible to the program that turns these pages into HTML, so I've moved it into the "value" part of each name:value pair.